### PR TITLE
build: add `build` and `release` workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        os: [windows-latest]
 
     steps:
       - name: Checkout code
@@ -22,6 +22,10 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: "9.0.x"
+      - name: Download Dalamud
+        run: |
+          Invoke-WebRequest -Uri https://goatcorp.github.io/dalamud-distrib/stg/latest.zip -OutFile latest.zip
+          Expand-Archive -Force latest.zip "$env:AppData\XIVLauncher\addon\Hooks\dev"
       - name: Build with dotnet
         run: dotnet build --configuration Release --nologo ./AetherSenseRedux.sln
       - name: dotnet test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build
+
+on:
+  push:
+    branches: "*"
+    tags-ignore: "*"
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3.3.0
+        with:
+          fetch-depth: 0
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: "9.0.x"
+      - name: Build with dotnet
+        run: dotnet build --configuration Release --nologo ./AetherSenseRedux.sln
+      - name: dotnet test
+        run: dotnet test --configuration Release --nologo ./AetherSenseRedux.sln
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: AetherSenseRedux-${{ matrix.os }}
+          path: |
+            ./AetherSenseRedux/bin/Release/*.nupkg
+            ./AetherSenseRedux/bin/Release/*.snupkg
+            ./AetherSenseRedux/bin/Release/**/AetherSenseRedux*.dll
+            ./AetherSenseRedux/bin/Release/**/AetherSenseRedux*.xml
+            ./AetherSenseRedux/bin/Release/**/AetherSenseRedux*.pdb
+            ./AetherSenseRedux/bin/Release/**/AetherSenseRedux*.deps.json
+            ./AetherSenseRedux/bin/Release/*.dll
+            ./AetherSenseRedux/bin/Release/AetherSenseRedux/latest.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,7 @@ name: Build
 
 on:
   push:
-    branches: "*"
-    tags-ignore: "*"
+    branches: "master"
   pull_request:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+name: Create Release
+
+on:
+  push:
+    tags-ignore:
+      - testing_*
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "9.x.x"
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Download Dalamud
+        run: |
+          Invoke-WebRequest -Uri https://goatcorp.github.io/dalamud-distrib/stg/latest.zip -OutFile latest.zip
+          Expand-Archive -Force latest.zip "$env:AppData\XIVLauncher\addon\Hooks\dev"
+      - name: Build
+        run: |
+          $ver = '${{ github.ref_name }}'
+          invoke-expression 'dotnet build --no-restore --configuration Release --nologo -p:Version=$ver -p:FileVersion=$ver -p:AssemblyVersion=$ver'
+      - name: Write version into JSONs
+        run: |
+          $ver = '${{ github.ref_name }}'
+          $path = './AetherSenseRedux/bin/Release/AetherSenseRedux.json'
+          $json = Get-Content -Raw $path | ConvertFrom-Json
+          $json.AssemblyVersion = $ver
+          $content = $json | ConvertTo-Json
+          set-content -Path $path -Value $content
+      - name: Archive
+        run: Compress-Archive -Path AetherSenseRedux/bin/Release/* -DestinationPath AetherSenseRedux.zip
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v4.4.3
+        with:
+          path: |
+            ./AetherSenseRedux/bin/Release/*
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: AetherSenseRedux ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./AetherSenseRedux.zip
+          asset_name: AetherSenseRedux.zip
+          asset_content_type: application/zip
+
+      - name: Write out repo.json
+        run: |
+          $ver = '${{ github.ref_name }}'
+          $path = './repo.json'
+          $json = Get-Content -Raw $path | ConvertFrom-Json
+          $json[0].AssemblyVersion = $ver
+          $json[0].DownloadLinkInstall = $json.DownloadLinkInstall -replace '[^/]+/AetherSenseRedux.zip',"$ver/AetherSenseRedux.zip"
+          $json[0].DownloadLinkUpdate = $json.DownloadLinkUpdate -replace '[^/]+/AetherSenseRedux.zip',"$ver/AetherSenseRedux.zip"
+          $content = $json | ConvertTo-Json -AsArray
+          set-content -Path $path -Value $content
+      - name: Commit repo.json
+        run: |
+          git config --global user.name "Actions User"
+          git config --global user.email "actions@github.com"
+          git fetch origin main
+          git branch -f main ${{ github.sha }}
+          git checkout main
+          git add repo.json
+          git commit -m "[CI] Updating repo.json for ${{ github.ref_name }}" || true
+          git push origin main

--- a/repo.json
+++ b/repo.json
@@ -1,0 +1,17 @@
+[
+    {
+      "Author": "digital pet, emesinae",
+      "Name": "AetherSense Redux (18+)",
+      "InternalName": "AetherSenseRedux",
+      "Description": "An advanced haptic feedback plugin for game controllers, adult toys, and more using the Buttplug.io library. Requires Intiface Desktop to operate.",
+      "ApplicableVersion": "any",
+      "Punchline": "Advanced haptic feedback using Intiface",
+      "RepoUrl": "https://github.com/emesinae/AetherSenseRedux",
+      "AcceptsFeedback": true,
+      "DalamudApiLevel": 12,
+      "AssemblyVersion": "0.1.0.1",
+      "DownloadLinkInstall": "https://github.com/emesinae/AetherSenseRedux/releases/download/TBD/AetherSenseRedux.zip",
+      "DownloadLinkUpdate": "https://github.com/emesinae/AetherSenseRedux/releases/download/TBD/AetherSenseRedux.zip"
+    }
+  ]
+  


### PR DESCRIPTION
# Summary

- Adds a `build` workflow to run on PR updates and commits to `master` (based off of [Lumina's workflow](https://github.com/NotAdam/Lumina/blob/master/.github/workflows/build.yml)).
- Adds a `release` workflow to build, publish, and update `repo.json` (based off of [Moodles' workflow](https://github.com/kawaii/Moodles/blob/main/.github/workflows/release.yml))