### PR TITLE
build: Update workflow release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,24 +44,15 @@ jobs:
             ./AetherSenseRedux/bin/Release/*
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref }}
           release_name: AetherSenseRedux ${{ github.ref }}
           draft: false
           prerelease: false
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./AetherSenseRedux.zip
-          asset_name: AetherSenseRedux.zip
-          asset_content_type: application/zip
+          generate_release_notes: true
+          files: |
+            ./AetherSenseRedux.zip
 
       - name: Write out repo.json
         run: |


### PR DESCRIPTION
# Summary

- Replace [the unmaintained `github/create-release` action](https://github.com/actions/create-release) with [softprops `action-gh-release`](https://github.com/softprops/action-gh-release) and _hopefully_ remove need for separate step for adding files to the release.