### PR TITLE
feat: add device intensity to status display

### DIFF
--- a/AetherSenseRedux/Device.cs
+++ b/AetherSenseRedux/Device.cs
@@ -29,6 +29,18 @@ namespace AetherSenseRedux
         private int frameTime = 16;     // The target time per update, in this case 16ms = ~60 ups, and also a pipe dream for BLE toys.
         private WaitType _waitType;
 
+        public DeviceStatus Status
+        {
+            get
+            {
+                return new DeviceStatus
+                {
+                    LastIntensity = _lastIntensity,
+                    UPS = UPS,
+                };
+            }
+        }
+
         public Device(ButtplugClientDevice clientDevice,WaitType waitType)
         {
             ClientDevice = clientDevice;

--- a/AetherSenseRedux/DeviceStatus.cs
+++ b/AetherSenseRedux/DeviceStatus.cs
@@ -1,0 +1,11 @@
+namespace AetherSenseRedux;
+
+/// <summary>
+/// Publicly exposed information about a Device's current status.
+/// </summary>
+public class DeviceStatus
+{
+    public double UPS {get; init;}
+    
+    public double LastIntensity {get; init;}
+}

--- a/AetherSenseRedux/Plugin.cs
+++ b/AetherSenseRedux/Plugin.cs
@@ -106,14 +106,14 @@ namespace AetherSenseRedux
             }
         }
 
-        public Dictionary<string, double> ConnectedDevices
+        public Dictionary<string, DeviceStatus> ConnectedDevices
         {
             get
             {
-                Dictionary<string, double> result = new();
+                Dictionary<string, DeviceStatus> result = new();
                 foreach (Device device in DevicePool)
                 {
-                    result[device.Name] = device.UPS;
+                    result[device.Name] = device.Status;
                 }
                 return result;
             }

--- a/AetherSenseRedux/PluginUI.cs
+++ b/AetherSenseRedux/PluginUI.cs
@@ -182,7 +182,7 @@ namespace AetherSenseRedux
                             ImGui.Indent();
                             foreach (var device in plugin.ConnectedDevices)
                             {
-                                ImGui.Text(String.Format("{0} [{1}]",device.Key,(int)device.Value));
+                                ImGui.Text(String.Format("{0} - {1}%% [{2}]",device.Key, (int)(device.Value.LastIntensity * 100),(int)device.Value.UPS));
                             }
                             ImGui.Unindent();
                         }


### PR DESCRIPTION
# Summary 

- Adds new `DeviceStatus` class for transporting additional data about a device (instead of just the `UPS` value).
- Updates the device status text to include the current intensity as a percentage. 