### PR TITLE
build: add commit linting

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "husky": {
+      "version": "0.7.2",
+      "commands": [
+        "husky"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -20,6 +20,8 @@
 #echo 'Husky.Net is awesome!'
 
 dotnet husky run --name "commit-message-linter" --args "$1"
+
 echo
-echo Great work! 🥂
-echo
+echo Looks fantastic, just like you, cutie! 😍
+echo Great work! 🦋
+echo 

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,27 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+## husky task runner examples -------------------
+## Note : for local installation use 'dotnet' prefix. e.g. 'dotnet husky'
+
+## run all tasks
+#husky run
+
+### run all tasks with group: 'group-name'
+#husky run --group group-name
+
+## run task with name: 'task-name'
+#husky run --name task-name
+
+## pass hook arguments to task
+#husky run --args "$1" "$2"
+
+## or put your custom commands -------------------
+#echo 'Husky.Net is awesome!'
+
+dotnet husky run --name "commit-message-linter" --args "$1"
+echo
+echo Great work! 🥂
+echo
+
+dotnet husky run

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -23,5 +23,3 @@ dotnet husky run --name "commit-message-linter" --args "$1"
 echo
 echo Great work! 🥂
 echo
-
-dotnet husky run

--- a/.husky/csx/commit-lint.csx
+++ b/.husky/csx/commit-lint.csx
@@ -1,0 +1,16 @@
+using System.Text.RegularExpressions;
+
+private var pattern = @"^(?=.{1,90}$)(?:build|feat|ci|chore|docs|fix|perf|refactor|revert|style|test|wip)(?:\(.+\))*(?::).{4,}(?:#\d+)*(?<![\.\s])$";
+private var msg = File.ReadAllLines(Args[0])[0];
+
+if (Regex.IsMatch(msg, pattern))
+    return 0;
+
+Console.ForegroundColor = ConsoleColor.Red;
+Console.WriteLine("Invalid commit message");
+Console.ResetColor();
+Console.WriteLine("e.g: 'feat(scope): subject' or 'fix: subject'");
+Console.ForegroundColor = ConsoleColor.Gray;
+Console.WriteLine("more info: https://www.conventionalcommits.org/en/v1.0.0/");
+
+return 1;

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -20,4 +20,3 @@ dotnet husky run -v --group "pre-commit"
 ## or put your custom commands -------------------
 #echo 'Husky.Net is awesome!'
 
-dotnet husky run

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,23 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+## husky task runner examples -------------------
+## Note : for local installation use 'dotnet' prefix. e.g. 'dotnet husky'
+
+## run all tasks
+#husky run
+
+### run all tasks with group: 'group-name'
+#husky run --group group-name
+dotnet husky run -v --group "pre-commit"
+
+## run task with name: 'task-name'
+#husky run --name task-name
+
+## pass hook arguments to task
+#husky run --args "$1" "$2"
+
+## or put your custom commands -------------------
+#echo 'Husky.Net is awesome!'
+
+dotnet husky run

--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -1,0 +1,16 @@
+{
+   "tasks": [
+     {
+       "name": "commit-message-linter",
+       "command": "dotnet",
+       "args": ["husky", "exec", ".husky/csx/commit-lint.csx", "--args", "${args}"]
+     },
+     {
+       "name": "dotnet-format",
+       "group": "pre-commit",
+       "command": "dotnet-format",
+       "args": ["--include", "${staged}"],
+       "include": ["**/*.cs"]
+     }
+   ]
+ }

--- a/README.md
+++ b/README.md
@@ -32,10 +32,24 @@ TODO: Write usage instructions
 
 ### Environment Config
 
+#### FFXIV and Dalamud
+
 - XIVLauncher must be installed and present.
   - If a custom path is required for Dalamud's dev directory, it must be set with the `DALAMUD_HOME` environment variable. The correct path will be to Dalamud's `Hooks/dev` directory. Examples of this are:
     - Windows: `$APPDATA\XIVLauncher\addon\Hooks\dev\`
     - Linux: `$HOME/.xlcore/dalamud/Hooks/dev`
+
+#### Development Dependencies
+
+If you want to try to contribute, ensure .NET dependencies and tools are installed by running:
+
+```sh
+dotnet restore
+dotnet tool restore
+```
+
+The latter is required to ensure you have [Husky](https://alirezanet.github.io/Husky.Net/) installed. If you attempt to commit changes and receive errors
+mentioning `husky`, then you probably need to make sure it is actually installed.
 
 ### Support
 


### PR DESCRIPTION
# Summary

- Adds [Husky](https://alirezanet.github.io/Husky.Net/) and pre-commit hooks to ensure commits match [conventional-commit style guides](https://www.conventionalcommits.org/en/v1.0.0/). 
- Updates README to include notes on installing dependencies.