### PR TITLE
fix(connection): reduce disconnects and device freezes

### DIFF
--- a/AetherSenseRedux/Device.cs
+++ b/AetherSenseRedux/Device.cs
@@ -120,8 +120,7 @@ namespace AetherSenseRedux
                 Patterns.Clear();
             }
 
-            var t = Task.Run(() => Write(0));
-            t.Wait();
+            Write(0).Wait();
         }
 
         /// <summary>
@@ -180,10 +179,10 @@ namespace AetherSenseRedux
             try
             {
                 await ClientDevice.VibrateAsync(clampedIntensity);
-
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                Service.PluginLog.Warning($"Error while trying to send vibration value to device '{this.Name}': {ex.Message}.");
                 // Connecting to an intiface server on Linux will spam the log with bluez errors
                 // so we just ignore all exceptions from this statement. Good? Probably not. Necessary? Yes.
             }


### PR DESCRIPTION
# Summary

I'm not exactly sure what the root causes were, but maintaining the websocket connection seems to have stopped most of the random disconnections, and the async tweaks have reduced errors thrown when disconnecting. Overall, connection reliability seems to be greatly increased. 