### PR TITLE
fix: always clear triggers to prevent duplicates

### DIFF
--- a/AetherSenseRedux/Plugin.cs
+++ b/AetherSenseRedux/Plugin.cs
@@ -559,6 +559,7 @@ namespace AetherSenseRedux
         /// </summary>
         public void Start()
         {
+            CleanTriggers();
             InitTriggers();
             Task.Run(InitButtplug);
         }


### PR DESCRIPTION
# Summary

Always calls `CleanTriggers()` before initializing them. This fixes duplicate triggers being created after an error causes a disconnect. 