### PR TITLE
refactor: move device management code into `DeviceService`

### DIFF
--- a/AetherSenseRedux/Plugin.cs
+++ b/AetherSenseRedux/Plugin.cs
@@ -15,6 +15,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using AetherSenseRedux.Hooks;
+using AetherSenseRedux.Toy;
 using AetherSenseRedux.Trigger.Emote;
 using Lumina.Excel.Sheets;
 

--- a/AetherSenseRedux/Plugin.cs
+++ b/AetherSenseRedux/Plugin.cs
@@ -29,95 +29,11 @@ namespace AetherSenseRedux
 
         private Configuration Configuration { get; set; }
 
-        private ButtplugStatus _status;
-
         private EmoteReaderHooks _emoteReaderHooks;
-
-        public ButtplugStatus Status
-        {
-            get
-            {
-                try
-                {
-                    if (_buttplug == null)
-                    {
-                        return ButtplugStatus.Uninitialized;
-                    }
-                    else if (_buttplug.Connected && _status == ButtplugStatus.Connected)
-                    {
-                        return ButtplugStatus.Connected;
-                    }
-                    else if (_status == ButtplugStatus.Connecting)
-                    {
-                        return ButtplugStatus.Connecting;
-                    }
-                    else if (!_buttplug.Connected && _status == ButtplugStatus.Connected)
-                    {
-                        return ButtplugStatus.Error;
-                    }
-                    else if (_status == ButtplugStatus.Disconnecting)
-                    {
-                        return ButtplugStatus.Disconnecting;
-                    }
-                    else if (LastException != null)
-                    {
-                        return ButtplugStatus.Error;
-                    }
-                    else
-                    {
-                        return ButtplugStatus.Disconnected;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Service.PluginLog.Error(ex, "error when getting status");
-                    return ButtplugStatus.Error;
-                }
-
-
-            }
-        }
-
-        public bool Scanning
-        {
-            get
-            {
-                if (_buttplug == null)
-                {
-                    return false;
-                }
-                // Buttplug.IsScanning no longer exists?
-                // return Buttplug.IsScanning;
-                return false;
-            }
-        }
-
-        private bool Connected => _buttplug?.Connected ?? false;
-
-        public Dictionary<string, DeviceStatus> ConnectedDevices
-        {
-            get
-            {
-                Dictionary<string, DeviceStatus> result = new();
-                foreach (var device in _devicePool)
-                {
-                    result[device.Name] = device.Status;
-                }
-
-                return result;
-            }
-        }
-
-        public Exception? LastException { get; set; }
-
-        public WaitType WaitType { get; set; }
 
         private PluginUI PluginUi { get; init; }
 
-        private ButtplugClient? _buttplug;
-        private ButtplugWebsocketConnector? _buttplugWebsocketConnector;
-
-        private List<Device> _devicePool;
+        internal DeviceService DeviceService;
 
         private readonly List<ChatTrigger> _chatTriggerPool;
         private readonly List<EmoteTrigger> _emoteTriggerPool;
@@ -133,16 +49,14 @@ namespace AetherSenseRedux
             Service.Plugin = this;
             Service.PluginInterface = PluginInterface;
 
-            var t = DoBenchmark();
-
-            this._devicePool = [];
+            this.DeviceService = new DeviceService();
+            this.DeviceService.DeviceAdded += DeviceServiceOnDeviceAdded;
+            this.DeviceService.Stopped += DeviceServiceOnStopped;
             this._chatTriggerPool = [];
             this._emoteTriggerPool = [];
 
             Configuration = PluginInterface.GetPluginConfig() as Configuration ?? new Configuration();
             Configuration.FixDeserialization();
-
-            _status = ButtplugStatus.Disconnected;
 
             // Update the configuration if it's an older version
             if (Configuration.Version == 1)
@@ -169,9 +83,6 @@ namespace AetherSenseRedux
 
             this._emoteReaderHooks = new EmoteReaderHooks();
             this._emoteReaderHooks.OnEmote += OnEmoteReceived;
-
-            t.Wait();
-            WaitType = t.Result;
         }
 
         /// <summary>
@@ -179,107 +90,26 @@ namespace AetherSenseRedux
         /// </summary>
         public void Dispose()
         {
-            Stop(true);
+            CleanTriggers();
+            DeviceService.Dispose();
             PluginUi.Dispose();
             Service.CommandManager.RemoveHandler(CommandName);
             _emoteReaderHooks.Dispose();
         }
 
         // EVENT HANDLERS
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void OnDeviceAdded(object? sender, DeviceAddedEventArgs e)
-        {
 
-            Service.PluginLog.Information("Device {0} added", e.Device.Name);
-            Device newDevice = new(e.Device, WaitType);
-            lock (this._devicePool)
-            {
-                this._devicePool.Add(newDevice);
-            }
-            if (!Configuration.SeenDevices.Contains(newDevice.Name))
-            {
-                Configuration.SeenDevices.Add(newDevice.Name);
-            }
-            newDevice.Start();
 
-        }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void OnDeviceRemoved(object? sender, DeviceRemovedEventArgs e)
-        {
-            if (Status != ButtplugStatus.Connected)
-            {
-                return;
-            }
-            Service.PluginLog.Information("Device {0} removed", e.Device.Name);
-            var toRemove = new List<Device>();
-            lock (this._devicePool)
-            {
-                foreach (var device in this._devicePool.Where(device => device.ClientDevice == e.Device))
-                {
-                    try
-                    {
-                        device.Stop();
-                    }
-                    catch (Exception ex)
-                    {
-                        Service.PluginLog.Error(ex, "Could not stop device {0}, device disconnected?", device.Name);
-                    }
-                    toRemove.Add(device);
-                    device.Dispose();
-                }
-            }
-            foreach (var device in toRemove)
-            {
-                lock (this._devicePool)
-                {
-                    this._devicePool.Remove(device);
-                }
-
-            }
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void OnScanComplete(object? sender, EventArgs e)
-        {
-            // Do nothing, since Buttplug still keeps scanning for BLE devices even after scanning is "complete"
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void OnServerDisconnect(object? sender, EventArgs e)
-        {
-            if (Status == ButtplugStatus.Disconnecting)
-            {
-                return;
-            }
-
-            Stop(false);
-            Service.PluginLog.Error("Unexpected disconnect.");
-        }
-
-        private void OnChatReceived(XivChatType type, int timestamp, ref SeString sender, ref SeString message, ref bool isHandled)
+        private void OnChatReceived(XivChatType type, int timestamp, ref SeString sender, ref SeString message,
+            ref bool isHandled)
         {
             ChatMessage chatMessage = new(type, timestamp, ref sender, ref message, ref isHandled);
             foreach (var t in _chatTriggerPool)
             {
                 t.Queue(chatMessage);
             }
+
             if (Configuration.LogChat)
             {
                 Service.PluginLog.Debug(chatMessage.ToString());
@@ -293,7 +123,9 @@ namespace AetherSenseRedux
 
             var emote = Service.DataManager.GetExcelSheet<Emote>().GetRowOrDefault(e.EmoteId);
 
-            Service.PluginLog.Debug($"{e.Instigator.Name} performed emote {emote?.Name.ExtractText() ?? "UNKNOWN"} ({e.EmoteId})" + (e.Target != null ? $" on target {e.Target.Name}" : string.Empty));
+            Service.PluginLog.Debug(
+                $"{e.Instigator.Name} performed emote {emote?.Name.ExtractText() ?? "UNKNOWN"} ({e.EmoteId})" +
+                (e.Target != null ? $" on target {e.Target.Name}" : string.Empty));
 
             var emoteLogItem = new EmoteLogItem
             {
@@ -330,167 +162,18 @@ namespace AetherSenseRedux
         /// <param name="patternConfig">A pattern configuration.</param>
         public void DoPatternTest(dynamic patternConfig)
         {
-            if (Status != ButtplugStatus.Connected)
+            if (DeviceService.Status != ButtplugStatus.Connected)
             {
                 return;
             }
 
-            lock (_devicePool)
-            {
-                foreach (var device in this._devicePool)
-                {
-                    lock (device.Patterns)
-                    {
-                        device.Patterns.Add(PatternFactory.GetPatternFromObject(patternConfig));
-                    }
-                }
-            }
+            this.DeviceService.AddPatternTest(patternConfig);
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <returns>The task associated with this method.</returns>
-        private async Task DoScan()
-        {
-            try
-            {
-                await _buttplug!.StartScanningAsync();
-            }
-            catch (Exception ex)
-            {
-                Service.PluginLog.Error(ex, "Asynchronous scanning failed.");
-            }
-        }
         // END SOME FUNCTIONS THAT DO THINGS
 
         // START AND STOP FUNCTIONS
-        /// <summary>
-        /// 
-        /// </summary>
-        private async Task InitButtplug()
-        {
-            LastException = null;
-            _status = ButtplugStatus.Connecting;
 
-            if (_buttplug == null)
-            {
-                _buttplug = new ButtplugClient("AetherSense Redux");
-                _buttplug.DeviceAdded += OnDeviceAdded;
-                _buttplug.DeviceRemoved += OnDeviceRemoved;
-                _buttplug.ScanningFinished += OnScanComplete;
-                _buttplug.ServerDisconnect += OnServerDisconnect;
-            }
-
-            if (!Connected)
-            {
-                try
-                {
-                    _buttplugWebsocketConnector = new ButtplugWebsocketConnector(new Uri(Configuration.Address));
-                    await _buttplug.ConnectAsync(_buttplugWebsocketConnector);
-                    _ = DoScan();
-                }
-                catch (Exception ex)
-                {
-                    Service.PluginLog.Error(ex, "Buttplug failed to connect.");
-                    LastException = ex;
-                    Stop(false);
-                }
-            }
-
-            if (Connected)
-            {
-                Service.PluginLog.Information("Buttplug connected.");
-                _status = ButtplugStatus.Connected;
-            }
-
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        private async Task DisconnectButtplugAsync()
-        {
-            if (_buttplug?.Connected == true)
-            {
-                try
-                {
-                    if (_buttplugWebsocketConnector?.Connected ?? false)
-                    {
-                        Service.PluginLog.Debug("Websocket is still connected. Disconnecting...");
-                        await _buttplugWebsocketConnector.DisconnectAsync();
-                        _buttplugWebsocketConnector = null;
-                        Service.PluginLog.Debug("Websocket disconnected");
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Service.PluginLog.Error(ex, "Failed to disconnect Buttplug websocket.");
-                }
-
-                try
-                {
-                    await _buttplug!.DisconnectAsync();
-                    Service.PluginLog.Information("Buttplug disconnected.");
-                }
-                catch (Exception ex)
-                {
-                    Service.PluginLog.Error(ex, "Failed to disconnect Buttplug.");
-                }
-            }
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        private void CleanDevices()
-        {
-            lock (_devicePool)
-            {
-                foreach (var device in _devicePool)
-                {
-                    Service.PluginLog.Debug("Stopping device {0}", device.Name);
-                    device.Stop();
-                    device.Dispose();
-                }
-                _devicePool.Clear();
-            }
-            Service.PluginLog.Debug("Devices destroyed.");
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        private async Task CleanButtplugAsync()
-        {
-            if (_buttplug == null)
-            {
-                _status = ButtplugStatus.Disconnected;
-                return;
-            }
-
-            try
-            {
-                _status = ButtplugStatus.Disconnecting;
-                await DisconnectButtplugAsync();
-            }
-            catch (Exception ex)
-            {
-                Service.PluginLog.Error(ex, $"Error thrown while trying to disconnect: {ex.Message}");
-            }
-            finally
-            {
-                _buttplug = null;
-                _status = ButtplugStatus.Disconnected;
-            }
-
-            Service.PluginLog.Debug("Buttplug destroyed.");
-        }
-
-        private void CleanButtplug()
-        {
-            CleanButtplugAsync().Wait();
-        }
 
         /// <summary>
         /// 
@@ -508,6 +191,7 @@ namespace AetherSenseRedux
                 Service.PluginLog.Debug("Stopping emote trigger {0}", t.Name);
                 t.Stop();
             }
+
             Service.ChatGui.ChatMessage -= OnChatReceived;
             _chatTriggerPool.Clear();
             _emoteTriggerPool.Clear();
@@ -524,7 +208,7 @@ namespace AetherSenseRedux
                 // We pass DevicePool by reference so that triggers don't get stuck with outdated copies
                 // of the device pool, should it be replaced with a new List<Device> - currently this doesn't
                 // happen, but it's possible it may happen in the future.
-                var trigger = TriggerFactory.GetTriggerFromConfig(d, ref _devicePool);
+                var trigger = TriggerFactory.GetTriggerFromConfig(d);
                 if (trigger.Type == "ChatTrigger")
                 {
                     _chatTriggerPool.Add((ChatTrigger)trigger);
@@ -562,7 +246,7 @@ namespace AetherSenseRedux
         {
             CleanTriggers();
             InitTriggers();
-            Task.Run(InitButtplug);
+            DeviceService.Start(new Uri(Configuration.Address));
         }
 
         /// <summary>
@@ -570,7 +254,7 @@ namespace AetherSenseRedux
         /// </summary>
         public void Reload()
         {
-            if (!Connected) return;
+            if (!DeviceService.Connected) return;
             CleanTriggers();
             InitTriggers();
         }
@@ -580,9 +264,20 @@ namespace AetherSenseRedux
         /// </summary>
         public void Stop(bool expected)
         {
+            DeviceService.Stop();
+        }
+
+        private void DeviceServiceOnDeviceAdded(Device device)
+        {
+            if (!Configuration.SeenDevices.Contains(device.Name))
+            {
+                Configuration.SeenDevices.Add(device.Name);
+            }
+        }
+
+        private void DeviceServiceOnStopped(object? sender, EventArgs e)
+        {
             CleanTriggers();
-            CleanDevices();
-            CleanButtplug();
         }
         // END START AND STOP FUNCTIONS
 
@@ -594,87 +289,11 @@ namespace AetherSenseRedux
         {
             this.PluginUi.Draw();
         }
+
         private void DrawConfigUI()
         {
             PluginUi.SettingsVisible = !PluginUi.SettingsVisible;
         }
         // END UI FUNCTIONS
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <returns></returns>
-        private static async Task<WaitType> DoBenchmark()
-        {
-            var result = WaitType.Slow_Timer;
-            var times = new long[10];
-            long sum = 0;
-            var averages = new double[2];
-            Stopwatch timer = new();
-            Service.PluginLog.Information("Starting benchmark");
-
-
-            Service.PluginLog.Debug("Testing Task.Delay");
-
-            for (var i = 0; i < times.Length; i++)
-            {
-                timer.Restart();
-                await Task.Delay(1);
-                times[i] = timer.Elapsed.Ticks;
-            }
-            foreach (var t in times)
-            {
-                Service.PluginLog.Debug("{0}", t);
-                sum += t;
-            }
-            averages[0] = (double)sum / times.Length / 10000;
-            Service.PluginLog.Debug("Average: {0}", averages[0]);
-
-            Service.PluginLog.Debug("Testing Thread.Sleep");
-            times = new long[10];
-            for (var i = 0; i < times.Length; i++)
-            {
-                timer.Restart();
-                Thread.Sleep(1);
-                times[i] = timer.Elapsed.Ticks;
-            }
-            sum = 0;
-            foreach (var t in times)
-            {
-                Service.PluginLog.Debug("{0}", t);
-                sum += t;
-            }
-            averages[1] = (double)sum / times.Length / 10000;
-            Service.PluginLog.Debug("Average: {0}", averages[1]);
-
-            if (averages[0] < 3)
-            {
-                result = WaitType.Use_Delay;
-
-            }
-            else if (averages[1] < 3)
-            {
-                result = WaitType.Use_Sleep;
-
-            }
-
-            switch (result)
-            {
-                case WaitType.Use_Delay:
-                    Service.PluginLog.Information("High resolution Task.Delay found, using delay in timing loops.");
-                    break;
-                case WaitType.Use_Sleep:
-                    Service.PluginLog.Information("High resolution Thread.Sleep found, using sleep in timing loops.");
-                    break;
-                case WaitType.Slow_Timer:
-                default:
-                    Service.PluginLog.Information("No high resolution, CPU-friendly waits available, timing loops will be inaccurate.");
-                    break;
-            }
-
-            return result;
-
-        }
-
     }
 }

--- a/AetherSenseRedux/PluginUI.cs
+++ b/AetherSenseRedux/PluginUI.cs
@@ -136,14 +136,14 @@ namespace AetherSenseRedux
                             _workingCopy.Address = address;
                         }
                         ImGui.SameLine();
-                        if (Service.Plugin.Status == ButtplugStatus.Connected)
+                        if (Service.Plugin.DeviceService.Status == ButtplugStatus.Connected)
                         {
                             if (ImGui.Button("Disconnect"))
                             {
                                 Service.Plugin.Stop(true);
                             }
                         }
-                        else if (Service.Plugin.Status == ButtplugStatus.Connecting || Service.Plugin.Status == ButtplugStatus.Disconnecting)
+                        else if (Service.Plugin.DeviceService.Status == ButtplugStatus.Connecting || Service.Plugin.DeviceService.Status == ButtplugStatus.Disconnecting)
                         {
                             if (ImGui.Button("Wait..."))
                             {
@@ -161,23 +161,23 @@ namespace AetherSenseRedux
 
                         ImGui.Spacing();
                         ImGui.BeginChild("status", new Vector2(0, 0), true);
-                        if (Service.Plugin.WaitType == WaitType.Slow_Timer)
+                        if (Service.Plugin.DeviceService.WaitType == WaitType.Slow_Timer)
                         {
                             ImGui.TextColored(new Vector4(1, 0, 0, 1), "High resolution timers not available, patterns will be inaccurate.");
                         }
                         ImGui.Text("Connection Status:");
                         ImGui.Indent();
-                        ImGui.Text(Service.Plugin.Status == ButtplugStatus.Connected ? "Connected" : Service.Plugin.Status == ButtplugStatus.Connecting ? "Connecting..." : Service.Plugin.Status == ButtplugStatus.Error ? "Error" : "Disconnected");
-                        if (Service.Plugin.LastException != null)
+                        ImGui.Text(Service.Plugin.DeviceService.Status == ButtplugStatus.Connected ? "Connected" : Service.Plugin.DeviceService.Status == ButtplugStatus.Connecting ? "Connecting..." : Service.Plugin.DeviceService.Status == ButtplugStatus.Error ? "Error" : "Disconnected");
+                        if (Service.Plugin.DeviceService.LastException != null)
                         {
-                            ImGui.Text(Service.Plugin.LastException.Message);
+                            ImGui.Text(Service.Plugin.DeviceService.LastException.Message);
                         }
                         ImGui.Unindent();
-                        if (Service.Plugin.Status == ButtplugStatus.Connected)
+                        if (Service.Plugin.DeviceService.Status == ButtplugStatus.Connected)
                         {
                             ImGui.Text("Devices Connected:");
                             ImGui.Indent();
-                            foreach (var device in Service.Plugin.ConnectedDevices)
+                            foreach (var device in Service.Plugin.DeviceService.ConnectedDevices)
                             {
                                 ImGui.Text($"{device.Key} - {(int)(device.Value.LastIntensity * 100)}%% [{(int)device.Value.UPS}]");
                             }

--- a/AetherSenseRedux/Toy/Device.cs
+++ b/AetherSenseRedux/Toy/Device.cs
@@ -7,7 +7,7 @@ using AetherSenseRedux.Pattern;
 using Buttplug.Client;
 using System.Threading;
 
-namespace AetherSenseRedux
+namespace AetherSenseRedux.Toy
 {
     internal class Device : IDisposable
     {

--- a/AetherSenseRedux/Toy/DeviceService.cs
+++ b/AetherSenseRedux/Toy/DeviceService.cs
@@ -1,0 +1,447 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AetherSenseRedux.Pattern;
+using Buttplug.Client;
+
+namespace AetherSenseRedux.Toy;
+
+internal class DeviceService : IDisposable, IAsyncDisposable
+{
+    public delegate void DeviceDelegate(Device device);
+
+    public event DeviceDelegate? DeviceAdded;
+    public event EventHandler? Stopped;
+
+    public WaitType WaitType { get; set; }
+
+    private readonly List<Device> _devicePool;
+
+    private ButtplugClient? _buttplug;
+    private ButtplugWebsocketConnector? _buttplugWebsocketConnector;
+    private ButtplugStatus _status;
+    public bool Connected => _buttplug?.Connected ?? false;
+    public Exception? LastException { get; set; }
+
+
+    public DeviceService()
+    {
+        this._devicePool = [];
+        _status = ButtplugStatus.Disconnected;
+
+        var t = DoBenchmark();
+        t.Wait();
+        WaitType = t.Result;
+    }
+
+    public Dictionary<string, DeviceStatus> ConnectedDevices
+    {
+        get
+        {
+            Dictionary<string, DeviceStatus> result = new();
+            foreach (var device in _devicePool)
+            {
+                result[device.Name] = device.Status;
+            }
+
+            return result;
+        }
+    }
+
+    public ButtplugStatus Status
+    {
+        get
+        {
+            try
+            {
+                if (_buttplug == null)
+                {
+                    return ButtplugStatus.Uninitialized;
+                }
+                else if (_buttplug.Connected && _status == ButtplugStatus.Connected)
+                {
+                    return ButtplugStatus.Connected;
+                }
+                else if (_status == ButtplugStatus.Connecting)
+                {
+                    return ButtplugStatus.Connecting;
+                }
+                else if (!_buttplug.Connected && _status == ButtplugStatus.Connected)
+                {
+                    return ButtplugStatus.Error;
+                }
+                else if (_status == ButtplugStatus.Disconnecting)
+                {
+                    return ButtplugStatus.Disconnecting;
+                }
+                else if (LastException != null)
+                {
+                    return ButtplugStatus.Error;
+                }
+                else
+                {
+                    return ButtplugStatus.Disconnected;
+                }
+            }
+            catch (Exception ex)
+            {
+                Service.PluginLog.Error(ex, "error when getting status");
+                return ButtplugStatus.Error;
+            }
+
+
+        }
+    }
+
+    public ReadOnlyCollection<Device> Devices => new ReadOnlyCollection<Device>(_devicePool);
+
+    public void Start(Uri address)
+    {
+        Task.Run(() => InitButtplug(address));
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    private async Task InitButtplug(Uri address)
+    {
+        LastException = null;
+        _status = ButtplugStatus.Connecting;
+
+        if (_buttplug == null)
+        {
+            _buttplug = new ButtplugClient("AetherSense Redux");
+            _buttplug.DeviceAdded += OnDeviceAdded;
+            _buttplug.DeviceRemoved += OnDeviceRemoved;
+            _buttplug.ScanningFinished += OnScanComplete;
+            _buttplug.ServerDisconnect += OnServerDisconnect;
+        }
+
+        if (!Connected)
+        {
+            try
+            {
+                _buttplugWebsocketConnector = new ButtplugWebsocketConnector(address);
+                await _buttplug.ConnectAsync(_buttplugWebsocketConnector);
+                _ = DoScan();
+            }
+            catch (Exception ex)
+            {
+                Service.PluginLog.Error(ex, "Buttplug failed to connect.");
+                LastException = ex;
+                Stop();
+            }
+        }
+
+        if (Connected)
+        {
+            Service.PluginLog.Information("Buttplug connected.");
+            _status = ButtplugStatus.Connected;
+        }
+
+    }
+
+    private void RemoveClientDevice(ButtplugClientDevice clientDevice)
+    {
+        var toRemove = new List<Device>();
+        lock (this._devicePool)
+        {
+            foreach (var device in this._devicePool.Where(device => device.ClientDevice == clientDevice))
+            {
+                try
+                {
+                    device.Stop();
+                }
+                catch (Exception ex)
+                {
+                    Service.PluginLog.Error(ex, "Could not stop device {0}, device disconnected?", device.Name);
+                }
+                toRemove.Add(device);
+                device.Dispose();
+            }
+        }
+        foreach (var device in toRemove)
+        {
+            lock (this._devicePool)
+            {
+                this._devicePool.Remove(device);
+            }
+
+        }
+    }
+
+    public void AddPatternTest(dynamic patternConfig)
+    {
+        lock (_devicePool)
+        {
+            foreach (var device in this._devicePool)
+            {
+                lock (device.Patterns)
+                {
+                    device.Patterns.Add(PatternFactory.GetPatternFromObject(patternConfig));
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <returns>The task associated with this method.</returns>
+    private async Task DoScan()
+    {
+        try
+        {
+            await _buttplug!.StartScanningAsync();
+        }
+        catch (Exception ex)
+        {
+            Service.PluginLog.Error(ex, "Asynchronous scanning failed.");
+        }
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    private async Task DisconnectButtplugAsync()
+    {
+        if (_buttplug?.Connected == true)
+        {
+            try
+            {
+                if (_buttplugWebsocketConnector?.Connected ?? false)
+                {
+                    Service.PluginLog.Debug("Websocket is still connected. Disconnecting...");
+                    await _buttplugWebsocketConnector.DisconnectAsync();
+                    _buttplugWebsocketConnector = null;
+                    Service.PluginLog.Debug("Websocket disconnected");
+                }
+            }
+            catch (Exception ex)
+            {
+                Service.PluginLog.Error(ex, "Failed to disconnect Buttplug websocket.");
+            }
+
+            try
+            {
+                await _buttplug!.DisconnectAsync();
+                Service.PluginLog.Information("Buttplug disconnected.");
+            }
+            catch (Exception ex)
+            {
+                Service.PluginLog.Error(ex, "Failed to disconnect Buttplug.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    private async Task CleanButtplugAsync()
+    {
+        if (_buttplug == null)
+        {
+            _status = ButtplugStatus.Disconnected;
+            return;
+        }
+
+        try
+        {
+            _status = ButtplugStatus.Disconnecting;
+            await DisconnectButtplugAsync();
+        }
+        catch (Exception ex)
+        {
+            Service.PluginLog.Error(ex, $"Error thrown while trying to disconnect: {ex.Message}");
+        }
+        finally
+        {
+            _buttplug = null;
+            _status = ButtplugStatus.Disconnected;
+        }
+
+        Service.PluginLog.Debug("Buttplug destroyed.");
+    }
+
+    private void CleanButtplug()
+    {
+        CleanButtplugAsync().Wait();
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    private void CleanDevices()
+    {
+        lock (_devicePool)
+        {
+            foreach (var device in _devicePool)
+            {
+                Service.PluginLog.Debug("Stopping device {0}", device.Name);
+                device.Stop();
+                device.Dispose();
+            }
+            _devicePool.Clear();
+        }
+        Service.PluginLog.Debug("Devices destroyed.");
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private void OnDeviceAdded(object? sender, DeviceAddedEventArgs e)
+    {
+
+        Service.PluginLog.Information("Device {0} added", e.Device.Name);
+        Device newDevice = new(e.Device, WaitType);
+        lock (this._devicePool)
+        {
+            this._devicePool.Add(newDevice);
+        }
+        this.DeviceAdded?.Invoke(newDevice);
+
+        newDevice.Start();
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private void OnDeviceRemoved(object? sender, DeviceRemovedEventArgs e)
+    {
+        if (Status != ButtplugStatus.Connected)
+        {
+            return;
+        }
+        Service.PluginLog.Information("Device {0} removed", e.Device.Name);
+        this.RemoveClientDevice(e.Device);
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private void OnScanComplete(object? sender, EventArgs e)
+    {
+        // Do nothing, since Buttplug still keeps scanning for BLE devices even after scanning is "complete"
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private void OnServerDisconnect(object? sender, EventArgs e)
+    {
+        if (Status == ButtplugStatus.Disconnecting)
+        {
+            return;
+        }
+
+        Stop();
+        Service.PluginLog.Error("Unexpected disconnect.");
+    }
+
+    public void Stop()
+    {
+        this.Stopped?.Invoke(this, EventArgs.Empty);
+        CleanDevices();
+        CleanButtplug();
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <returns></returns>
+    private static async Task<WaitType> DoBenchmark()
+    {
+        var result = WaitType.Slow_Timer;
+        var times = new long[10];
+        long sum = 0;
+        var averages = new double[2];
+        Stopwatch timer = new();
+        Service.PluginLog.Information("Starting benchmark");
+
+
+        Service.PluginLog.Debug("Testing Task.Delay");
+
+        for (var i = 0; i < times.Length; i++)
+        {
+            timer.Restart();
+            await Task.Delay(1);
+            times[i] = timer.Elapsed.Ticks;
+        }
+        foreach (var t in times)
+        {
+            Service.PluginLog.Debug("{0}", t);
+            sum += t;
+        }
+        averages[0] = (double)sum / times.Length / 10000;
+        Service.PluginLog.Debug("Average: {0}", averages[0]);
+
+        Service.PluginLog.Debug("Testing Thread.Sleep");
+        times = new long[10];
+        for (var i = 0; i < times.Length; i++)
+        {
+            timer.Restart();
+            Thread.Sleep(1);
+            times[i] = timer.Elapsed.Ticks;
+        }
+        sum = 0;
+        foreach (var t in times)
+        {
+            Service.PluginLog.Debug("{0}", t);
+            sum += t;
+        }
+        averages[1] = (double)sum / times.Length / 10000;
+        Service.PluginLog.Debug("Average: {0}", averages[1]);
+
+        if (averages[0] < 3)
+        {
+            result = WaitType.Use_Delay;
+
+        }
+        else if (averages[1] < 3)
+        {
+            result = WaitType.Use_Sleep;
+
+        }
+
+        switch (result)
+        {
+            case WaitType.Use_Delay:
+                Service.PluginLog.Information("High resolution Task.Delay found, using delay in timing loops.");
+                break;
+            case WaitType.Use_Sleep:
+                Service.PluginLog.Information("High resolution Thread.Sleep found, using sleep in timing loops.");
+                break;
+            case WaitType.Slow_Timer:
+            default:
+                Service.PluginLog.Information("No high resolution, CPU-friendly waits available, timing loops will be inaccurate.");
+                break;
+        }
+
+        return result;
+
+    }
+
+    public void Dispose()
+    {
+        CleanDevices();
+        CleanButtplug();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        CleanDevices();
+        await CleanButtplugAsync();
+    }
+}

--- a/AetherSenseRedux/Toy/DeviceStatus.cs
+++ b/AetherSenseRedux/Toy/DeviceStatus.cs
@@ -1,4 +1,4 @@
-namespace AetherSenseRedux;
+namespace AetherSenseRedux.Toy;
 
 /// <summary>
 /// Publicly exposed information about a Device's current status.

--- a/AetherSenseRedux/Trigger/ChatTrigger.cs
+++ b/AetherSenseRedux/Trigger/ChatTrigger.cs
@@ -19,7 +19,6 @@ namespace AetherSenseRedux.Trigger
         public bool Enabled { get; set; }
         public string Type { get; } = "ChatTrigger";
         public string Name { get; init; }
-        public List<Device> Devices { get; init; }
         public List<string> EnabledDevices { get; init; }
         public PatternConfig PatternSettings { get; init; }
         private XIVChatFilter Filter { get; init; }
@@ -38,12 +37,11 @@ namespace AetherSenseRedux.Trigger
         /// <param name="configuration">The configuration object for this trigger.</param>
         /// <param name="devices">A reference to the list of Buttplug Devices.</param>
         /// <returns>A ChatTrigger object.</returns>
-        public ChatTrigger(ChatTriggerConfig configuration, ref List<Device> devices)
+        public ChatTrigger(ChatTriggerConfig configuration)
         {
             // ITrigger properties
             Enabled = true;
             Name = configuration.Name;
-            Devices = devices;
             EnabledDevices = configuration.EnabledDevices;
             PatternSettings = PatternFactory.GetPatternConfigFromObject(configuration.PatternSettings);
 
@@ -89,19 +87,17 @@ namespace AetherSenseRedux.Trigger
                     RetriggerTime = DateTime.UtcNow + TimeSpan.FromMilliseconds(RetriggerDelay);
                 }
             }
-            lock (Devices)
-            {
-                foreach (Device device in Devices)
-                {
-                    if (EnabledDevices.Contains(device.Name))
-                    {
-                        lock (device.Patterns)
-                        {
-                            device.Patterns.Add(PatternFactory.GetPatternFromObject(PatternSettings));
-                        }
-                    }
 
+            foreach (Device device in Service.Plugin.DeviceService.Devices)
+            {
+                if (EnabledDevices.Contains(device.Name))
+                {
+                    lock (device.Patterns)
+                    {
+                        device.Patterns.Add(PatternFactory.GetPatternFromObject(PatternSettings));
+                    }
                 }
+
             }
         }
 

--- a/AetherSenseRedux/Trigger/ChatTrigger.cs
+++ b/AetherSenseRedux/Trigger/ChatTrigger.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Text.RegularExpressions;
 using System.Collections.Concurrent;
+using AetherSenseRedux.Toy;
 using XIVChatTypes;
 
 namespace AetherSenseRedux.Trigger

--- a/AetherSenseRedux/Trigger/Emote/EmoteTrigger.cs
+++ b/AetherSenseRedux/Trigger/Emote/EmoteTrigger.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using AetherSenseRedux.Pattern;
-using XIVChatTypes;
+using AetherSenseRedux.Toy;
 
 namespace AetherSenseRedux.Trigger.Emote;
 

--- a/AetherSenseRedux/Trigger/TriggerFactory.cs
+++ b/AetherSenseRedux/Trigger/TriggerFactory.cs
@@ -12,12 +12,12 @@ namespace AetherSenseRedux.Trigger
 {
     internal class TriggerFactory
     {
-        public static ITrigger GetTriggerFromConfig(TriggerConfig config, ref List<Device> devices)
+        public static ITrigger GetTriggerFromConfig(TriggerConfig config)
         {
             return config.Type switch
             {
-                "Chat" => new ChatTrigger((ChatTriggerConfig)config, ref devices),
-                "Emote" => new EmoteTrigger((EmoteTriggerConfig)config, ref devices),
+                "Chat" => new ChatTrigger((ChatTriggerConfig)config),
+                "Emote" => new EmoteTrigger((EmoteTriggerConfig)config),
                 _ => throw new ArgumentException($"Invalid trigger {config.Type} specified")
             };
         }

--- a/AetherSenseRedux/Trigger/TriggerFactory.cs
+++ b/AetherSenseRedux/Trigger/TriggerFactory.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Linq;
 using System.Collections.Generic;
 using AetherSenseRedux.Pattern;
+using AetherSenseRedux.Toy;
 using AetherSenseRedux.Trigger.Emote;
 using Microsoft.CSharp.RuntimeBinder;
 using Newtonsoft.Json.Linq;


### PR DESCRIPTION
# Summary

- Moves device related classes into `Toy` namespace.
- Moves device management code from `Plugin` into separate `DeviceService`
- Stops injecting device list into each trigger, instead having them query directly from the device service. 