### PR TITLE
fix: Use consistent dalamud version in csproj and repo.json

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -8,7 +8,7 @@
     "Punchline": "Advanced haptic feedback using Intiface",
     "RepoUrl": "https://github.com/emesinae/AetherSenseRedux",
     "AcceptsFeedback": true,
-    "DalamudApiLevel": 12,
+    "DalamudApiLevel": 13,
     "AssemblyVersion": "1.1.2",
     "DownloadLinkInstall": "https://github.com/emesinae/AetherSenseRedux/releases/download/v1.1.2/AetherSenseRedux.zip",
     "DownloadLinkUpdate": "https://github.com/emesinae/AetherSenseRedux/releases/download/v1.1.2/AetherSenseRedux.zip"


### PR DESCRIPTION
Updates repo.json to Dalamud v13, to match the version in csproj and to allow Dalamud to install from the https://raw.githubusercontent.com/emesinae/AetherSenseRedux/main/repo.json repository URL