### PR TITLE
build(github): generate repo.json from plugin metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,13 +28,14 @@ jobs:
           Invoke-WebRequest -Uri https://goatcorp.github.io/dalamud-distrib/stg/latest.zip -OutFile latest.zip
           Expand-Archive -Force latest.zip "$env:AppData\XIVLauncher\addon\Hooks\dev"
       - name: Build with dotnet
+        id: build
         run: dotnet build --configuration Release --nologo ./AetherSenseRedux.sln
       - name: dotnet test
         run: dotnet test --configuration Release --nologo ./AetherSenseRedux.sln
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: AetherSenseRedux-${{ matrix.os }}
+          name: AetherSenseRedux-${{ matrix.os }}-build
           path: |
             ./AetherSenseRedux/bin/Release/*.nupkg
             ./AetherSenseRedux/bin/Release/*.snupkg
@@ -44,3 +45,24 @@ jobs:
             ./AetherSenseRedux/bin/Release/**/AetherSenseRedux*.deps.json
             ./AetherSenseRedux/bin/Release/*.dll
             ./AetherSenseRedux/bin/Release/AetherSenseRedux/latest.zip
+      - name: Upload a Plugin Artifact
+        id: upload_plugin
+        uses: actions/upload-artifact@v4
+        with:
+          name: AetherSenseRedux-${{ matrix.os }}
+          path: |
+            ./AetherSenseRedux/bin/Release/AetherSenseRedux/latest.zip
+      - name: Test generating repo.json
+        if: steps.build.outcome == 'success'
+        shell: nu {0}
+        run: |
+          const downloadUrl = '${{ steps.upload_plugin.outputs.artifact-url }}'
+
+          mut pkg = open './AetherSenseRedux/bin/Release/AetherSenseRedux.json'
+          $pkg = $pkg | merge {
+            DownloadLinkInstall: $downloadUrl,
+            DownloadLinkUpdate: $downloadUrl
+          }
+
+          # just echo the JSON for testing
+          [ $pkg ] | to json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
           # submodules: recursive
           fetch-depth: 0
           fetch-tags: true
+      - uses: hustcer/setup-nu@v3
+        with:
+          version: "*"
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
@@ -77,18 +80,23 @@ jobs:
           generate_release_notes: true
           files: |
             ./AetherSenseRedux.zip
-
       - name: Write out repo.json
         if: steps.versionize.outcome == 'success'
+        shell: nu {0}
         run: |
-          $ver = '${{ steps.version.outputs.VERSION }}'
-          $path = './repo.json'
-          $json = Get-Content -Raw $path | ConvertFrom-Json
-          $json[0].AssemblyVersion = $ver
-          $json[0].DownloadLinkInstall = $json.DownloadLinkInstall -replace '[^/]+/AetherSenseRedux.zip',"v$ver/AetherSenseRedux.zip"
-          $json[0].DownloadLinkUpdate = $json.DownloadLinkUpdate -replace '[^/]+/AetherSenseRedux.zip',"v$ver/AetherSenseRedux.zip"
-          $content = $json | ConvertTo-Json -AsArray
-          set-content -Path $path -Value $content
+          const version = '${{ steps.version.outputs.VERSION }}'
+          const releaseAssets = '${{ steps.create_release.outputs.assets }}' | from json
+          const downloadUrl = $releaseAssets.0.browser_download_url
+          const outputPath = './repo.json'
+
+          mut pkg = open './AetherSenseRedux/bin/Release/AetherSenseRedux.json'
+          let $pkg | merge {
+            DownloadLinkInstall: $downloadUrl,
+            DownloadLinkUpdate: $downloadUrl
+          }
+
+          let repo = [$pkg]
+          $repo | to json | save -f $outputPath
       - name: Commit repo.json
         if: steps.versionize.outcome == 'success'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
           const outputPath = './repo.json'
 
           mut pkg = open './AetherSenseRedux/bin/Release/AetherSenseRedux.json'
-          let $pkg | merge {
+          $pkg = $pkg | merge {
             DownloadLinkInstall: $downloadUrl,
             DownloadLinkUpdate: $downloadUrl
           }

--- a/AetherSenseRedux/AetherSenseRedux.json
+++ b/AetherSenseRedux/AetherSenseRedux.json
@@ -1,11 +1,10 @@
 {
-  "Author": "digital pet",
+  "Author": "Tama Gotchi (digital-pet), Emesinae",
   "Name": "AetherSense Redux (18+)",
   "Punchline": "Advanced haptic feedback using Intiface",
   "Description": "An advanced haptic feedback plugin for game controllers, adult toys, and more using the Buttplug.io library. Requires Intiface Desktop to operate.",
-  "InternalName": "AetherSenseRedux",
   "IsTestingExclusive": false,
-  "RepoUrl": "https://github.com/digital-pet/AetherSenseRedux",
+  "RepoUrl": "https://github.com/emesinae/AetherSenseRedux",
   "ApplicableVersion": "any",
   "Tags": [
     "parsing",


### PR DESCRIPTION
# Summary

Updates the Github Action configuration to generate the `repo.json` file from the plugin's metadata.