### PR TITLE
Add various combination modes

### DIFF
--- a/AetherSenseRedux/Configuration.cs
+++ b/AetherSenseRedux/Configuration.cs
@@ -1,6 +1,7 @@
 ﻿using AetherSenseRedux.Pattern;
 using AetherSenseRedux.Trigger;
 using Dalamud.Configuration;
+using Microsoft.CSharp.RuntimeBinder;
 using System;
 using System.Collections.Generic;
 
@@ -9,9 +10,18 @@ namespace AetherSenseRedux
     [Serializable]
     public class Configuration : IPluginConfiguration
     {
+        public enum CombineMode
+        {
+            Average,
+            Maximum,
+            Add,
+            Asymptotic,
+        }
+
         public int Version { get; set; } = 2;
         public bool FirstRun = true;
         public bool LogChat { get; set; } = false;
+        public CombineMode Combiner { get; set; } = CombineMode.Add;
         public string Address { get; set; } = "ws://127.0.0.1:12345";
         public List<string> SeenDevices { get; set; } = new();
         public List<dynamic> Triggers { get; set; } = new List<dynamic>();
@@ -93,6 +103,14 @@ namespace AetherSenseRedux
                 }
                 FirstRun = o.FirstRun;
                 LogChat = o.LogChat;
+                try
+                {
+                    Combiner = o.Combiner;
+                }
+                catch (RuntimeBinderException ex)
+                {
+                    Service.PluginLog.Info(ex, "Combiner wasn't available; is this an older config file? Defaulting to AddClamped.");
+                }
                 Address = o.Address;
                 SeenDevices = new List<string>(o.SeenDevices);
                 Triggers = o.Triggers;

--- a/AetherSenseRedux/Plugin.cs
+++ b/AetherSenseRedux/Plugin.cs
@@ -49,12 +49,6 @@ namespace AetherSenseRedux
             Service.Plugin = this;
             Service.PluginInterface = PluginInterface;
 
-            this.DeviceService = new DeviceService();
-            this.DeviceService.DeviceAdded += DeviceServiceOnDeviceAdded;
-            this.DeviceService.Stopped += DeviceServiceOnStopped;
-            this._chatTriggerPool = [];
-            this._emoteTriggerPool = [];
-
             Configuration = PluginInterface.GetPluginConfig() as Configuration ?? new Configuration();
             Configuration.FixDeserialization();
 
@@ -70,6 +64,12 @@ namespace AetherSenseRedux
             {
                 Configuration.LoadDefaults();
             }
+
+            this.DeviceService = new DeviceService(Configuration);
+            this.DeviceService.DeviceAdded += DeviceServiceOnDeviceAdded;
+            this.DeviceService.Stopped += DeviceServiceOnStopped;
+            this._chatTriggerPool = [];
+            this._emoteTriggerPool = [];
 
             PluginUi = new PluginUI(Configuration);
 

--- a/AetherSenseRedux/PluginUI.cs
+++ b/AetherSenseRedux/PluginUI.cs
@@ -271,6 +271,21 @@ namespace AetherSenseRedux
                         {
                             _workingCopy.LoadDefaults();
                         }
+
+                        if (ImGui.BeginCombo("Combine Mode", _workingCopy.Combiner.ToString()))
+                        {
+                            foreach (Configuration.CombineMode mode in Enum.GetValues(typeof(Configuration.CombineMode)))
+                            {
+                                if (ImGui.Selectable(mode.ToString(), mode == _workingCopy.Combiner))
+                                {
+                                    _workingCopy.Combiner = mode;
+                                }
+
+                                if (mode == _workingCopy.Combiner) ImGui.SetItemDefaultFocus();
+                            }
+                            ImGui.EndCombo();
+                        }
+
                         ImGui.EndTabItem();
                     }
                     ImGui.EndTabBar();

--- a/AetherSenseRedux/Toy/DeviceService.cs
+++ b/AetherSenseRedux/Toy/DeviceService.cs
@@ -26,10 +26,11 @@ internal class DeviceService : IDisposable, IAsyncDisposable
     private ButtplugStatus _status;
     public bool Connected => _buttplug?.Connected ?? false;
     public Exception? LastException { get; set; }
+    private readonly Configuration configuration;
 
-
-    public DeviceService()
+    public DeviceService(Configuration configuration)
     {
+        this.configuration = configuration;
         this._devicePool = [];
         _status = ButtplugStatus.Disconnected;
 
@@ -299,7 +300,7 @@ internal class DeviceService : IDisposable, IAsyncDisposable
     {
 
         Service.PluginLog.Information("Device {0} added", e.Device.Name);
-        Device newDevice = new(e.Device, WaitType);
+        Device newDevice = new(this.configuration, e.Device, WaitType);
         lock (this._devicePool)
         {
             this._devicePool.Add(newDevice);


### PR DESCRIPTION
"Average" is probably one of the oddest options we could default to, isn't it? If you have one strong signal and a low signal kicks in, average would _reduce_ the vibration intensity, even though you now have two "sources" of haptics.

So I added an enum to Configuration containing four combination modes, propagated the configuration object through to DeviceService and Device (had to reorder creation of DeviceService slightly but I don't see any conflicts), implemented the combination modes in Device, and added the UI to the advanced tab of PluginUI.

The four modes, for reference:
- Average: The original behavior, takes the mean of the input signals.
- Max: Chooses the largest input signal.
- Add: Sums all the signals. (The result is only clamped to 0..1 afterward, so if we ever have negative signals, they can "penalize" the output signal.)
- Asymptotic: 1 - (1 - sig1)(1 - sig2)...(1 - sigN). Again, input signals are not pre-clamped; a negative signal can reduce the output and a greater-than-1 signal can increase it. (The final value is still clamped though.) (I played around with some graphs to check this mode, and while it *looks* okay, and clamping to 0..1 afterward should keep it contained, the behavior might be... unpredictable.)

I set the default to "add", though this is notably a change in the default behavior.

Resolves issue #16, I hope.