### PR TITLE
Discover pattern implementations at runtime

### DIFF
--- a/AetherSenseRedux/Pattern/ConstantPattern.cs
+++ b/AetherSenseRedux/Pattern/ConstantPattern.cs
@@ -1,9 +1,61 @@
 ﻿
 using System;
 using System.Collections.Generic;
+using Dalamud.Bindings.ImGui;
 
 namespace AetherSenseRedux.Pattern
 {
+    internal class ConstantPatternType : IPatternType
+    {
+        public string Name => "Constant";
+
+        public PatternConfig GetDefaultConfiguration()
+        {
+            return new ConstantPatternConfig();
+        }
+
+        public PatternConfig DeserializeConfiguration(dynamic source)
+        {
+            return new ConstantPatternConfig()
+            {
+                Duration = (long)source.Duration,
+                Level = (double)source.Level,
+            };
+        }
+
+        public IPattern Create(PatternConfig config)
+        {
+            if (config is ConstantPatternConfig ccfg) return new ConstantPattern(ccfg);
+            throw new ArgumentException("config isn't ConstantPatternConfig");
+        }
+
+        /// <summary>
+        /// Draws the configuration interface for constant patterns
+        /// </summary>
+        /// <param name="pattern">A ConstantPatternConfig object containing the current configuration for the pattern.</param>
+        public void DrawSettings(PatternConfig config)
+        {
+            if (config is ConstantPatternConfig ccfg)
+            {
+                long duration = ccfg.Duration;
+                if (ImGui.InputLong("Duration (ms)", ref duration))
+                {
+                    ccfg.Duration = duration;
+                }
+
+                double level = ccfg.Level;
+                if (ImGui.InputDouble("Level", ref level))
+                {
+                    ccfg.Level = level;
+                }
+            }
+            else
+            {
+                ImGui.Text("Internal error: config is not ConstantPatternConfig");
+            }
+        }
+    }
+
     internal class ConstantPattern : IPattern
     {
         public DateTime Expires { get; set; }

--- a/AetherSenseRedux/Pattern/IPattern.cs
+++ b/AetherSenseRedux/Pattern/IPattern.cs
@@ -6,6 +6,17 @@ using System.Threading.Tasks;
 
 namespace AetherSenseRedux.Pattern
 {
+    internal interface IPatternType
+    {
+        public static readonly Dictionary<string, IPatternType> All = Util.Discovery.DefaultInstances<IPatternType>()
+            .ToDictionary(x => x.Name);
+
+        public abstract string Name { get; }
+        public PatternConfig GetDefaultConfiguration();
+        public PatternConfig DeserializeConfiguration(dynamic source);
+        public IPattern Create(PatternConfig config);
+        public void DrawSettings(PatternConfig config);
+    }
 
     internal interface IPattern
     {

--- a/AetherSenseRedux/Pattern/PatternFactory.cs
+++ b/AetherSenseRedux/Pattern/PatternFactory.cs
@@ -10,87 +10,17 @@ namespace AetherSenseRedux.Pattern
     {
         public static IPattern GetPatternFromObject(PatternConfig settings)
         {
-            switch (settings.Type)
-            {
-                case "Constant":
-                    return new ConstantPattern((ConstantPatternConfig)settings);
-                case "Ramp":
-                    return new RampPattern((RampPatternConfig)settings);
-                case "Saw":
-                    return new SawPattern((SawPatternConfig)settings);
-                case "Random":
-                    return new RandomPattern((RandomPatternConfig)settings);
-                case "Square":
-                    return new SquarePattern((SquarePatternConfig)settings);
-                default:
-                    throw new ArgumentException(String.Format("Invalid pattern {0} specified", settings.Type));
-            }
+            return IPatternType.All[settings.Type].Create(settings);
         }
 
         public static PatternConfig GetDefaultsFromString(string name)
         {
-            switch (name)
-            {
-                case "Constant":
-                    return ConstantPattern.GetDefaultConfiguration();
-                case "Ramp":
-                    return RampPattern.GetDefaultConfiguration();
-                case "Saw":
-                    return SawPattern.GetDefaultConfiguration();
-                case "Random":
-                    return RandomPattern.GetDefaultConfiguration();
-                case "Square":
-                    return SquarePattern.GetDefaultConfiguration();
-                default:
-                    throw new ArgumentException(String.Format("Invalid pattern {0} specified", name));
-            }
+            return IPatternType.All[name].GetDefaultConfiguration();
         }
 
         public static PatternConfig GetPatternConfigFromObject(dynamic o)
         {
-            switch ((string)o.Type)
-            {
-                case "Constant":
-                    return new ConstantPatternConfig()
-                    {
-                        Duration = (long)o.Duration,
-                        Level = (double)o.Level
-                    };
-                case "Ramp":
-                    return new RampPatternConfig()
-                    {
-                        Duration = (long)o.Duration,
-                        Start = (double)o.Start,
-                        End = (double)o.End
-                    };
-                case "Saw":
-                    return new SawPatternConfig()
-                    {
-                        Duration = (long)o.Duration,
-                        Start = (double)o.Start,
-                        End = (double)o.End,
-                        Duration1 = (long)o.Duration1
-                    };
-                case "Random":
-                    return new RandomPatternConfig()
-                    {
-                        Duration = (long)o.Duration,
-                        Minimum = (double)o.Minimum,
-                        Maximum = (double)o.Maximum
-                    };
-                case "Square":
-                    return new SquarePatternConfig()
-                    {
-                        Duration = (long)o.Duration,
-                        Duration1 = (long)o.Duration1,
-                        Duration2 = (long)o.Duration2,
-                        Level1 = (double)o.Level1,
-                        Level2 = (double)o.Level2,
-                        Offset = (long)o.Offset
-                    };
-                default:
-                    throw new ArgumentException(String.Format("Invalid pattern {0} specified", o.Type));
-            }
+            return IPatternType.All[(string)o.Type].DeserializeConfiguration(o);
         }
     }
 }

--- a/AetherSenseRedux/Pattern/RampPattern.cs
+++ b/AetherSenseRedux/Pattern/RampPattern.cs
@@ -1,4 +1,5 @@
-﻿using Dalamud.Logging;
+﻿using Dalamud.Bindings.ImGui;
+using Dalamud.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,6 +8,62 @@ using System.Threading.Tasks;
 
 namespace AetherSenseRedux.Pattern
 {
+    internal class RampPatternType : IPatternType
+    {
+        public string Name => "Ramp";
+
+        public PatternConfig GetDefaultConfiguration()
+        {
+            return new RampPatternConfig();
+        }
+
+        public PatternConfig DeserializeConfiguration(dynamic source)
+        {
+            return new RampPatternConfig()
+            {
+                Duration = (long)source.Duration,
+                Start = (double)source.Start,
+                End = (double)source.End,
+            };
+        }
+
+        public IPattern Create(PatternConfig config)
+        {
+            if (config is RampPatternConfig rpcfg) return new RampPattern(rpcfg);
+            throw new ArgumentException("config is not RampPatternConfig");
+        }
+
+        /// <summary>
+        /// Draws the configuration interface for ramp patterns
+        /// </summary>
+        /// <param name="pattern">A RampPatternConfig object containing the current configuration for the pattern.</param>
+        public void DrawSettings(PatternConfig config)
+        {
+            if (config is RampPatternConfig pattern)
+            {
+                int duration = (int)pattern.Duration;
+                if (ImGui.InputInt("Duration (ms)", ref duration))
+                {
+                    pattern.Duration = (long)duration;
+                }
+                double start = (double)pattern.Start;
+                if (ImGui.InputDouble("Start", ref start))
+                {
+                    pattern.Start = start;
+                }
+                double end = (double)pattern.End;
+                if (ImGui.InputDouble("End", ref end))
+                {
+                    pattern.End = end;
+                }
+            }
+            else
+            {
+                ImGui.Text("Internal error: config is not RampPatternConfig");
+            }
+        }
+    }
+
     internal class RampPattern : IPattern
     {
         public DateTime Expires { get; set; }

--- a/AetherSenseRedux/Pattern/RandomPattern.cs
+++ b/AetherSenseRedux/Pattern/RandomPattern.cs
@@ -3,9 +3,66 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Dalamud.Bindings.ImGui;
 
 namespace AetherSenseRedux.Pattern
 {
+    internal class RandomPatternType : IPatternType
+    {
+        public string Name => "Random";
+
+        public PatternConfig GetDefaultConfiguration()
+        {
+            return new RandomPatternConfig();
+        }
+
+        public PatternConfig DeserializeConfiguration(dynamic source)
+        {
+            return new RandomPatternConfig()
+            {
+                Duration = (long)source.Duration,
+                Minimum = (double)source.Minimum,
+                Maximum = (double)source.Maximum,
+            };
+        }
+
+        public IPattern Create(PatternConfig config)
+        {
+            if (config is RandomPatternConfig rpcfg) return new RandomPattern(rpcfg);
+            throw new ArgumentException("config is not RandomPatternConfig");
+        }
+
+        /// <summary>
+        /// Draws the configuration interface for random patterns
+        /// </summary>
+        /// <param name="pattern">A RandomPatternConfig object containing the current configuration for the pattern.</param>
+        public void DrawSettings(PatternConfig config)
+        {
+            if (config is RandomPatternConfig pattern)
+            {
+                int duration = (int)pattern.Duration;
+                if (ImGui.InputInt("Duration (ms)", ref duration))
+                {
+                    pattern.Duration = (long)duration;
+                }
+                double min = (double)pattern.Minimum;
+                if (ImGui.InputDouble("Minimum", ref min))
+                {
+                    pattern.Minimum = min;
+                }
+                double max = (double)pattern.Maximum;
+                if (ImGui.InputDouble("Maximum", ref max))
+                {
+                    pattern.Maximum = max;
+                }
+            }
+            else
+            {
+                ImGui.Text("Internal error: config is not RandomPatternConfig");
+            }
+        }
+    }
+
     internal class RandomPattern : IPattern
     {
         public DateTime Expires { get; set; }

--- a/AetherSenseRedux/Pattern/SawPattern.cs
+++ b/AetherSenseRedux/Pattern/SawPattern.cs
@@ -1,4 +1,5 @@
-﻿using Dalamud.Logging;
+﻿using Dalamud.Bindings.ImGui;
+using Dalamud.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,6 +8,68 @@ using System.Threading.Tasks;
 
 namespace AetherSenseRedux.Pattern
 {
+    internal class SawPatternType : IPatternType
+    {
+        public string Name => "Saw";
+
+        public PatternConfig GetDefaultConfiguration()
+        {
+            return new SawPatternConfig();
+        }
+
+        public PatternConfig DeserializeConfiguration(dynamic source)
+        {
+            return new SawPatternConfig()
+            {
+                Duration = (long)source.Duration,
+                Start = (double)source.Start,
+                End = (double)source.End,
+                Duration1 = (long)source.Duration1,
+            };
+        }
+
+        public IPattern Create(PatternConfig config)
+        {
+            if (config is SawPatternConfig spcfg) return new SawPattern(spcfg);
+            throw new ArgumentException("config is not SawPatternConfig");
+        }
+
+        /// <summary>
+        /// Draws the configuration interface for saw patterns
+        /// </summary>
+        /// <param name="pattern">A SawPatternConfig object containing the current configuration for the pattern.</param>
+        public void DrawSettings(PatternConfig config)
+        {
+            if (config is SawPatternConfig pattern)
+            {
+                int duration = (int)pattern.Duration;
+                if (ImGui.InputInt("Duration (ms)", ref duration))
+                {
+                    pattern.Duration = (long)duration;
+                }
+                double start = (double)pattern.Start;
+                if (ImGui.InputDouble("Start", ref start))
+                {
+                    pattern.Start = start;
+                }
+                double end = (double)pattern.End;
+                if (ImGui.InputDouble("End", ref end))
+                {
+                    pattern.End = end;
+                }
+                int duration1 = (int)pattern.Duration1;
+                if (ImGui.InputInt("Saw Duration (ms)", ref duration1))
+                {
+                    pattern.Duration1 = (long)duration1;
+                }
+            }
+            else
+            {
+                ImGui.Text("Internal error: config is not SawPatternConfig");
+            }
+        }
+    }
+
     internal class SawPattern : IPattern
     {
         public DateTime Expires { get; set; }

--- a/AetherSenseRedux/Pattern/SquarePattern.cs
+++ b/AetherSenseRedux/Pattern/SquarePattern.cs
@@ -1,8 +1,83 @@
 ﻿using System;
+using Dalamud.Bindings.ImGui;
 
 
 namespace AetherSenseRedux.Pattern
 {
+    internal class SquarePatternType : IPatternType
+    {
+        public string Name => "Square";
+
+        public PatternConfig GetDefaultConfiguration()
+        {
+            return new SquarePatternConfig();
+        }
+
+        public PatternConfig DeserializeConfiguration(dynamic source)
+        {
+            return new SquarePatternConfig()
+            {
+                Duration = (long)source.Duration,
+                Level1 = (double)source.Level1,
+                Level2 = (double)source.Level2,
+                Duration1 = (long)source.Duration1,
+                Duration2 = (long)source.Duration2,
+                Offset = (long)source.Offset,
+            };
+        }
+
+        public IPattern Create(PatternConfig config)
+        {
+            if (config is SquarePatternConfig spcfg) return new SquarePattern(spcfg);
+            throw new ArgumentException("config is not SquarePatternConfig");
+        }
+
+        /// <summary>
+        /// Draws the configuration interface for square patterns
+        /// </summary>
+        /// <param name="pattern">A SquarePatternConfig object containing the current configuration for the pattern.</param>
+        public void DrawSettings(PatternConfig config)
+        {
+            if (config is SquarePatternConfig pattern)
+            {
+                int duration = (int)pattern.Duration;
+                if (ImGui.InputInt("Duration (ms)", ref duration))
+                {
+                    pattern.Duration = (long)duration;
+                }
+                double level1 = (double)pattern.Level1;
+                if (ImGui.InputDouble("Level 1", ref level1))
+                {
+                    pattern.Level1 = level1;
+                }
+                int duration1 = (int)pattern.Duration1;
+                if (ImGui.InputInt("Level 1 Duration (ms)", ref duration1))
+                {
+                    pattern.Duration1 = (long)duration1;
+                }
+                double level2 = (double)pattern.Level2;
+                if (ImGui.InputDouble("Level 2", ref level2))
+                {
+                    pattern.Level2 = level2;
+                }
+                int duration2 = (int)pattern.Duration2;
+                if (ImGui.InputInt("Level 2 Duration (ms)", ref duration2))
+                {
+                    pattern.Duration2 = (long)duration2;
+                }
+                int offset = (int)pattern.Offset;
+                if (ImGui.InputInt("Offset (ms)", ref offset))
+                {
+                    pattern.Offset = (long)offset;
+                }
+            }
+            else
+            {
+                ImGui.Text("Internal error: config is not SquarePatternConfig");
+            }
+        }
+    }
+
     internal class SquarePattern : IPattern
     {
         public DateTime Expires { get; set; }

--- a/AetherSenseRedux/PluginUI.cs
+++ b/AetherSenseRedux/PluginUI.cs
@@ -245,7 +245,7 @@ namespace AetherSenseRedux
 
                         ImGui.BeginChild("right", new Vector2(0, 0), false);
                         ImGui.Indent(1);
-                        if (_workingCopy.Triggers.Count == 0)
+                        if (_workingCopy.Triggers.Count == 0 || _selectedTrigger < 0 || _selectedTrigger >= _workingCopy.Triggers.Count)
                         {
                             ImGui.Text("Use the Add New button to add a trigger.");
 
@@ -693,19 +693,17 @@ namespace AetherSenseRedux
             ////
             if (ImGui.BeginTabItem("Pattern"))
             {
-                string[] patterns = ["Constant", "Ramp", "Random", "Square", "Saw"];
-
                 //begin pattern selection
                 if (ImGui.BeginCombo("##combo", t.PatternSettings!.Type))
                 {
-                    foreach (var pattern in patterns)
+                    foreach (var pattern in IPatternType.All)
                     {
-                        bool isSelected = t.PatternSettings.Type == pattern;
-                        if (ImGui.Selectable(pattern, isSelected))
+                        bool isSelected = t.PatternSettings.Type == pattern.Key;
+                        if (ImGui.Selectable(pattern.Key, isSelected))
                         {
-                            if (t.PatternSettings.Type != pattern)
+                            if (t.PatternSettings.Type != pattern.Key)
                             {
-                                t.PatternSettings = PatternFactory.GetDefaultsFromString(pattern);
+                                t.PatternSettings = pattern.Value.GetDefaultConfiguration();
                             }
                         }
                         if (isSelected)
@@ -733,163 +731,19 @@ namespace AetherSenseRedux
                 ImGui.Indent();
 
                 //begin pattern settings
-                switch ((string)t.PatternSettings.Type)
+                if (IPatternType.All.TryGetValue((string)t.PatternSettings.Type, out IPatternType? activeType))
                 {
-                    case "Constant":
-                        DrawConstantPatternSettings(t.PatternSettings);
-                        break;
-                    case "Ramp":
-                        DrawRampPatternSettings(t.PatternSettings);
-                        break;
-                    case "Saw":
-                        DrawSawPatternSettings(t.PatternSettings);
-                        break;
-                    case "Random":
-                        DrawRandomPatternSettings(t.PatternSettings);
-                        break;
-                    case "Square":
-                        DrawSquarePatternSettings(t.PatternSettings);
-                        break;
-                    default:
-                        //we should never get here but just in case
+                    activeType.DrawSettings(t.PatternSettings);
+                }
+                else
+                {
                         ImGui.Text("Select a valid pattern.");
-                        break;
                 }
                 //end pattern settings
 
                 ImGui.Unindent();
 
                 ImGui.EndTabItem();
-            }
-        }
-
-        /// <summary>
-        /// Draws the configuration interface for constant patterns
-        /// </summary>
-        /// <param name="pattern">A ConstantPatternConfig object containing the current configuration for the pattern.</param>
-        private static void DrawConstantPatternSettings(dynamic pattern)
-        {
-            int duration = (int)pattern.Duration;
-            if (ImGui.InputInt("Duration (ms)", ref duration))
-            {
-                pattern.Duration = (long)duration;
-            }
-            double level = (double)pattern.Level;
-            if (ImGui.InputDouble("Level", ref level))
-            {
-                pattern.Level = level;
-            }
-        }
-
-        /// <summary>
-        /// Draws the configuration interface for ramp patterns
-        /// </summary>
-        /// <param name="pattern">A RampPatternConfig object containing the current configuration for the pattern.</param>
-        private static void DrawRampPatternSettings(dynamic pattern)
-        {
-            int duration = (int)pattern.Duration;
-            if (ImGui.InputInt("Duration (ms)", ref duration))
-            {
-                pattern.Duration = (long)duration;
-            }
-            double start = (double)pattern.Start;
-            if (ImGui.InputDouble("Start", ref start))
-            {
-                pattern.Start = start;
-            }
-            double end = (double)pattern.End;
-            if (ImGui.InputDouble("End", ref end))
-            {
-                pattern.End = end;
-            }
-        }
-
-        /// <summary>
-        /// Draws the configuration interface for saw patterns
-        /// </summary>
-        /// <param name="pattern">A SawPatternConfig object containing the current configuration for the pattern.</param>
-        private static void DrawSawPatternSettings(dynamic pattern)
-        {
-            int duration = (int)pattern.Duration;
-            if (ImGui.InputInt("Duration (ms)", ref duration))
-            {
-                pattern.Duration = (long)duration;
-            }
-            double start = (double)pattern.Start;
-            if (ImGui.InputDouble("Start", ref start))
-            {
-                pattern.Start = start;
-            }
-            double end = (double)pattern.End;
-            if (ImGui.InputDouble("End", ref end))
-            {
-                pattern.End = end;
-            }
-            int duration1 = (int)pattern.Duration1;
-            if (ImGui.InputInt("Saw Duration (ms)", ref duration1))
-            {
-                pattern.Duration1 = (long)duration1;
-            }
-        }
-
-        /// <summary>
-        /// Draws the configuration interface for random patterns
-        /// </summary>
-        /// <param name="pattern">A RandomPatternConfig object containing the current configuration for the pattern.</param>
-        private static void DrawRandomPatternSettings(dynamic pattern)
-        {
-            int duration = (int)pattern.Duration;
-            if (ImGui.InputInt("Duration (ms)", ref duration))
-            {
-                pattern.Duration = (long)duration;
-            }
-            double min = (double)pattern.Minimum;
-            if (ImGui.InputDouble("Minimum", ref min))
-            {
-                pattern.Minimum = min;
-            }
-            double max = (double)pattern.Maximum;
-            if (ImGui.InputDouble("Maximum", ref max))
-            {
-                pattern.Maximum = max;
-            }
-        }
-
-        /// <summary>
-        /// Draws the configuration interface for square patterns
-        /// </summary>
-        /// <param name="pattern">A SquarePatternConfig object containing the current configuration for the pattern.</param>
-        private static void DrawSquarePatternSettings(dynamic pattern)
-        {
-            int duration = (int)pattern.Duration;
-            if (ImGui.InputInt("Duration (ms)", ref duration))
-            {
-                pattern.Duration = (long)duration;
-            }
-            double level1 = (double)pattern.Level1;
-            if (ImGui.InputDouble("Level 1", ref level1))
-            {
-                pattern.Level1 = level1;
-            }
-            int duration1 = (int)pattern.Duration1;
-            if (ImGui.InputInt("Level 1 Duration (ms)", ref duration1))
-            {
-                pattern.Duration1 = (long)duration1;
-            }
-            double level2 = (double)pattern.Level2;
-            if (ImGui.InputDouble("Level 2", ref level2))
-            {
-                pattern.Level2 = level2;
-            }
-            int duration2 = (int)pattern.Duration2;
-            if (ImGui.InputInt("Level 2 Duration (ms)", ref duration2))
-            {
-                pattern.Duration2 = (long)duration2;
-            }
-            int offset = (int)pattern.Offset;
-            if (ImGui.InputInt("Offset (ms)", ref offset))
-            {
-                pattern.Offset = (long)offset;
             }
         }
     }

--- a/AetherSenseRedux/Util/Discovery.cs
+++ b/AetherSenseRedux/Util/Discovery.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace AetherSenseRedux.Util;
+
+public interface Discovery
+{
+    static HashSet<string> AssemblyBlacklist =
+    [
+        "HelixToolkit.SharpDX.Core",
+    ];
+
+    static IEnumerable<Type> ImplementersOf(Type iintf)
+    {
+        return AppDomain.CurrentDomain.GetAssemblies().SelectMany(x =>
+        {
+            string name = x.GetName()?.Name ?? "<anonymous assembly>";
+            if (AssemblyBlacklist.Contains(name)) return [];
+            try
+            {
+                return x.GetTypes();
+            }
+            catch (Exception exc)
+            {
+                Service.PluginLog.Warning($"Exception while getting types from {name}: {exc.Message}; blacklisting this assembly. Consider blacklisting it by default!");
+                AssemblyBlacklist.Add(name);
+                return [];
+            }
+        }).Where(x => iintf.IsAssignableFrom(x) && !x.IsInterface && !x.IsAbstract);
+    }
+
+    static IEnumerable<TYPE> DefaultInstances<TYPE>()
+    {
+        return ImplementersOf(typeof(TYPE)).Select(x => (TYPE?)Activator.CreateInstance(x)).Where(x => x != null).Select(x => x!);
+    }
+}


### PR DESCRIPTION
**Please note: This PR will necessarily conflict with [my user-curve change](https://github.com/emesinae/AetherSenseRedux/pull/27). Personally, I'd prefer to see *this* change merge; I'm happy to change user-curve to work in this system of pattern type listing.**

Rather than hardcoding the list of pattern types in numerous places, we should have a single list of all known pattern types. And if that list is dynamically generated from all implementations of an interface which can provide the various functions needed by PatternFactory and some extra metadata to boot, all the better. In my mind, this is a far cleaner approach to the internal code.

This is meant to significantly ease the addition of new patterns. I have in mind a similar refactor for trigger types.

I realize that bringing ImGui into the pattern sources might be seen as a breach of containment/separation of concerns, where previously the pattern files were strictly concerned with modelling the configuration and providing the intensity function, but now must also define their UI. While we could make a declarative UI for patterns, I think the nature of immediate-mode user interfaces kind of demands this integration. *shrug*