### PR TITLE
fix(devices): fix devices running long and/or disconnecting

### DIFF
--- a/AetherSenseRedux/Configuration.cs
+++ b/AetherSenseRedux/Configuration.cs
@@ -25,6 +25,10 @@ namespace AetherSenseRedux
         public string Address { get; set; } = "ws://127.0.0.1:12345";
         public List<string> SeenDevices { get; set; } = new();
         public List<dynamic> Triggers { get; set; } = new List<dynamic>();
+        /// <summary>
+        /// The minimum gap between messages sent to devices, in milliseconds.
+        /// </summary>
+        public double MinMessageGap { get; set; } = 30;
 
         /// <summary>
         /// Deep copies the trigger list while ensuring that everything has the correct type.
@@ -51,6 +55,7 @@ namespace AetherSenseRedux
         {
             Version = 2;
             FirstRun = false;
+            MinMessageGap = 30;
             Triggers = new List<dynamic>() {
                 new ChatTriggerConfig()
                 {
@@ -103,6 +108,7 @@ namespace AetherSenseRedux
                 }
                 FirstRun = o.FirstRun;
                 LogChat = o.LogChat;
+                MinMessageGap = o.MinMessageGap ?? 30;
                 try
                 {
                     Combiner = o.Combiner;

--- a/AetherSenseRedux/PluginUI.cs
+++ b/AetherSenseRedux/PluginUI.cs
@@ -286,6 +286,33 @@ namespace AetherSenseRedux
                             ImGui.EndCombo();
                         }
 
+                        if (ImGui.CollapsingHeader("Advanced (Ultimate)"))
+                        {
+                            ImGui.TextWrapped("These are the (even more) advanced settings. You probably don't need to change these.");
+                            var minMessageGap = (int)_workingCopy.MinMessageGap;
+
+                            ImGui.PushItemWidth(ImGui.GetContentRegionAvail().X * 0.4f);
+                            if (ImGui.DragInt("Min Message Delay (ms)", ref minMessageGap, 1, 0, 100))
+                            {
+                                _workingCopy.MinMessageGap = minMessageGap;
+                            }
+
+                            ImGui.SameLine();
+                            ImGui.TextDisabled("(?)");
+                            if (ImGui.IsItemHovered())
+                            {
+                                using (ImRaii.Tooltip())
+                                {
+                                    ImGui.Text("The minimum delay between messages");
+                                    ImGui.Text("sent to a device, in milliseconds.");
+                                    ImGui.Text("If devices seem to still be running");
+                                    ImGui.Text("after ASR shows the intensity as zero,");
+                                    ImGui.Text("then you might need to increase this.");
+                                    ImGui.TextDisabled("Default: 30");
+                                }
+                            }
+                        }
+
                         ImGui.EndTabItem();
                     }
                     ImGui.EndTabBar();

--- a/AetherSenseRedux/Toy/Device.cs
+++ b/AetherSenseRedux/Toy/Device.cs
@@ -181,7 +181,7 @@ namespace AetherSenseRedux.Toy
 
             double intensity = 0;
 
-            if (intensities.Any())
+            if (intensities.Count > 0)
             {
                 switch (configuration.Combiner)
                 {

--- a/AetherSenseRedux/Toy/Device.cs
+++ b/AetherSenseRedux/Toy/Device.cs
@@ -205,19 +205,19 @@ namespace AetherSenseRedux.Toy
                 return;
             }
 
+            // Skip messages if it has been less than the MinMessageGap
+            // This is to avoid filling up the device message queue,
+            // which can cause the devices to run longer than expected.
             var lastWriteMs = (DateTime.Now - this._lastWriteTime).TotalMilliseconds;
-            var timingCap = Math.Max(ClientDevice.MessageTimingGap, 30);
+            var timingCap = Math.Max(ClientDevice.MessageTimingGap, configuration.MinMessageGap);
             if (lastWriteMs < timingCap)
             {
                 return;
             }
 
-            //Service.PluginLog.Info($"writing {clampedIntensity}: {lastWriteMs} >= {timingCap} - {ClientDevice.Name}");
-
-            _lastIntensity = clampedIntensity;
-
             try
             {
+                this._lastIntensity = clampedIntensity;
                 this._lastWriteTime = DateTime.Now;
                 await ClientDevice.VibrateAsync(clampedIntensity).ConfigureAwait(false);
             }

--- a/AetherSenseRedux/Toy/Device.cs
+++ b/AetherSenseRedux/Toy/Device.cs
@@ -202,7 +202,7 @@ namespace AetherSenseRedux.Toy
                         break;
                 }
             }
-            await Write(intensity).ConfigureAwait(false);
+            await Write(intensity);
         }
 
         /// <summary>


### PR DESCRIPTION
# Summary

- Adds a configurable minimum message delay between messages sent to each device. This is hidden in the _Advanced_ tab, but it's hopefully a sane default. In my testing, 30ms was enough to ensure the devices always stopped when the pattern stopped. 
> <img width="580" height="294" alt="image" src="https://github.com/user-attachments/assets/077e3864-57b0-40c3-b1c9-6b0a31e1971b" />

- Adds occasional messages to help keep the Web Socket connection alive. In my testing, the web socket client was frequently disconnecting after about 20 seconds, but with this fix in place, I have not seen any random disconnects! 🎉